### PR TITLE
docs: establish repository documentation layout

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -1,0 +1,12 @@
+# Kerald Documentation
+
+Kerald is a distributed messaging framework intended to be easier to use than Kafka-class systems while staying lightweight, operationally simple, and efficiency-first across CPU, memory, network, and storage.
+
+Documentation is organized by decision type:
+
+- `requirements/`: product requirements, externally visible guarantees, and compatibility constraints.
+- `adr/`: architecture decision records for long-lived technical decisions.
+- `architecture/`: system design notes, component boundaries, protocols, and data-flow explanations.
+- `operations/`: configuration, rollout, failure handling, CI, release, and production operation guidance.
+
+Significant behavior or architecture changes should update the relevant requirements, ADR, test, telemetry, and operations documents as part of the same pull request.

--- a/docs/adr/0000-template.md
+++ b/docs/adr/0000-template.md
@@ -1,0 +1,23 @@
+# ADR 0000: Title
+
+Status: Proposed
+
+## Context
+
+Describe the problem, constraints, and forces that make this decision necessary.
+
+## Decision
+
+State the decision clearly. Include the boundary of the decision so future readers know what is and is not decided here.
+
+## Alternatives Considered
+
+List the meaningful alternatives and why they were not chosen.
+
+## Consequences
+
+Describe the positive and negative consequences, including compatibility, operational, performance, and maintenance impact.
+
+## Rollout or Migration Notes
+
+Describe rollout, migration, feature flag, backfill, or compatibility steps. If none are needed, state that explicitly.

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -1,0 +1,21 @@
+# Architecture Decision Records
+
+Use ADRs for decisions with long-term compatibility, operational, or architecture impact.
+
+Create or update an ADR when changing:
+
+- Consistency or cluster coordination.
+- Protocol models or wire compatibility.
+- Storage and durability boundaries.
+- Delivery and notification semantics.
+- Public APIs with long-term compatibility impact.
+
+Each ADR must include:
+
+- Context
+- Decision
+- Alternatives considered
+- Consequences, both positive and negative
+- Rollout or migration notes when applicable
+
+Number ADR files sequentially with a short kebab-case title, for example `0001-cluster-coordination.md`.

--- a/docs/architecture/README.md
+++ b/docs/architecture/README.md
@@ -1,0 +1,13 @@
+# Architecture
+
+This directory contains system architecture notes for Kerald.
+
+Architecture documents should explain component boundaries, protocols, data flow, consistency models, storage responsibilities, and operational behavior. They should preserve the mandatory system constraints:
+
+- Topics are partitionless.
+- Progress uses nanosecond timestamp cursors, not offsets.
+- Notification tracking is separate from payload delivery tracking.
+- Write admission is safety-first.
+- Persistence is Lance read/write only behind OpenDAL-backed storage boundaries.
+
+When an architecture document records a long-lived decision rather than explanatory context, add or update an ADR in `docs/adr/`.

--- a/docs/operations/README.md
+++ b/docs/operations/README.md
@@ -1,0 +1,11 @@
+# Operations
+
+This directory contains operational guidance for running, releasing, configuring, and protecting Kerald.
+
+Operational documents should cover deployment expectations, failure handling, rollout impact, production telemetry, CI, and repository governance. Production guidance must account for:
+
+- OpenTelemetry logs, metrics, and traces.
+- musl Alpine multi-stage container builds for lightweight runtime nodes.
+- Explicit failure-mode handling for write admission, storage, delivery, and cluster coordination.
+
+See `github-merge-gates.md` for repository merge protection and CI requirements.

--- a/docs/operations/pr-quality-gate.md
+++ b/docs/operations/pr-quality-gate.md
@@ -1,0 +1,22 @@
+# Pull Request Quality Gate
+
+Before requesting review, every Kerald pull request must document:
+
+- Partitionless semantics are preserved.
+- Timestamp cursor semantics are preserved.
+- Notification tracking remains separate from payload delivery tracking.
+- Safety-first write admission is preserved.
+- Tests are added or updated in the correct suite: unit, integration, performance, or Cucumber behavior.
+- Observable behavior changes include Cucumber coverage or an explicit documented rationale.
+- Telemetry impact is reviewed for OpenTelemetry logs, metrics, and traces.
+- Requirements, architecture docs, ADRs, and operations notes are updated when the decision surface changes.
+- Runtime and container impact is considered, including the musl Alpine multi-stage expectation.
+- New Rust crates are actively maintained when added and use the MIT or Apache-2.0 license.
+
+Forbidden patterns:
+
+- Reintroducing partition semantics.
+- Reintroducing offset-based progress tracking where timestamp cursors are required.
+- Silently degrading admission safety guarantees.
+- Adding embedded query-engine responsibilities to broker persistence.
+- Adding JNI for Java bindings.

--- a/docs/requirements/README.md
+++ b/docs/requirements/README.md
@@ -1,0 +1,11 @@
+# Requirements
+
+This directory contains product and system requirements for Kerald.
+
+Requirements should describe observable commitments and constraints rather than implementation details. Keep the core mission visible in each requirement set:
+
+- Easier to use than Kafka-class systems.
+- Lightweight and operationally simple.
+- Efficiency-first across CPU, memory, network, and storage while preserving strong performance.
+
+When a change affects public behavior, delivery guarantees, protocol compatibility, cursor semantics, storage boundaries, or runtime support, update or add a requirement document in this directory.

--- a/docs/requirements/product-mission.md
+++ b/docs/requirements/product-mission.md
@@ -1,0 +1,18 @@
+# Product Mission
+
+Kerald is a distributed messaging framework designed to be easier to use than Kafka-class systems while remaining lightweight, operationally simple, and efficiency-first.
+
+Core product requirements:
+
+- Support standalone broker mode and clustered broker mode.
+- Preserve partitionless topics: any node can accept writes, and public APIs must not expose partition concepts.
+- Reject ingress when eventual delivery guarantees cannot be upheld.
+- Track subscriber notification progress separately from payload delivery progress.
+- Use nanosecond timestamp cursors for progress; do not use offset-based progress where timestamp cursors are required.
+- Apply TTL precedence in this order: cluster default, topic override, message override.
+- Use QUIC as the baseline protocol, with extension points for gRPC, Arrow ADBC, MQTT, and Kafka-compatible front doors.
+- Represent payloads with Arrow.
+- Persist through Lance read/write boundaries only; brokers must not embed LanceDB query responsibilities.
+- Use OpenDAL for storage abstraction across local FS, S3, R2, GCS, and Azure Blob support paths.
+- Target Rust 1.92, Python 3.10+ bindings through PyO3, and Java 25+ bindings through the FFM API without JNI.
+- Include OpenTelemetry logs, metrics, and traces in production telemetry.


### PR DESCRIPTION
## Summary

Implements #1 by adding the baseline repository documentation layout for Kerald.

- Adds top-level documentation guidance under `docs/`.
- Adds requirements, ADR, architecture, and operations README files.
- Adds a product mission requirements document.
- Adds an ADR template with the required sections from `AGENTS.md`.
- Adds a PR quality gate document, including the new third-party Rust crate policy: crates must be actively maintained and MIT or Apache-2.0 licensed.

## Validation

- `test -f AGENTS.md && jq empty .devcontainer/devcontainer.json && jq empty .vscode/extensions.json && git diff --check`

Closes #1