### PR TITLE
docs: define cluster coordination ADR

### DIFF
--- a/docs/adr/0001-cluster-coordination.md
+++ b/docs/adr/0001-cluster-coordination.md
@@ -1,0 +1,73 @@
+# ADR 0001: Cluster Coordination Model
+
+Status: Proposed
+
+## Context
+
+Kerald must support both standalone and clustered broker modes while preserving partitionless topics. Any node may accept writes, but ingress must be rejected when eventual delivery guarantees cannot be upheld.
+
+Cluster coordination needs to be resilient under node failure, network interruption, restart, and storage recovery. The model is TigerBeetle-inspired: deterministic state transitions, explicit quorum requirements, durable replicated decisions, and conservative admission when the cluster cannot prove safety.
+
+This decision must not introduce partition-based APIs or offset-based progress. Client progress remains based on nanosecond timestamp cursors, and subscriber notification tracking remains separate from payload delivery tracking.
+
+## Decision
+
+Kerald clustered mode will use a replicated coordination log for cluster metadata and write-admission decisions. The log records deterministic decisions for membership, topic metadata, broker health, durability commitments, and ingress admission epochs.
+
+The initial clustered model will use a fixed voting set configured at cluster creation. A write is admissible only when the accepting broker can prove that the coordination quorum and required durability path are available for the current admission epoch. If quorum, storage, or replication health is uncertain, the broker rejects ingress with an explicit unsafe-admission error.
+
+Replication expectations:
+
+- Coordination decisions require a quorum of the configured voting set.
+- A committed coordination decision is durable before it is externally observed.
+- Brokers apply committed decisions in log order.
+- Broker-local state may cache committed decisions but must not invent authority outside the committed log.
+
+Failure handling:
+
+- Loss of quorum stops new clustered write admission.
+- Brokers may continue read or payload-poll paths only when doing so does not violate delivery guarantees.
+- Rejoining brokers must replay committed coordination state before accepting clustered writes.
+- Conflicting membership or admission epochs are resolved by committed log order, not wall-clock order.
+
+Required observability signals:
+
+- Current coordination role and voting-set membership.
+- Quorum availability and loss-of-quorum transitions.
+- Coordination commit latency and replication lag.
+- Admission epoch changes.
+- Unsafe-admission rejection counts and reasons.
+- Broker replay progress after restart or rejoin.
+
+## Alternatives Considered
+
+Partition-owner coordination was rejected because Kerald topics are partitionless and public APIs must not expose partition concepts.
+
+Best-effort gossip-only coordination was rejected because it cannot provide a strong enough basis for safety-first write admission.
+
+Single-leader metadata stored only in local broker state was rejected because it creates a durability and recovery boundary that is too weak for clustered operation.
+
+Offset-based replication progress was rejected because Kerald progress and cursors use nanosecond timestamps where client-visible progress is involved. Internal coordination log positions may exist as implementation details, but they must not become client progress semantics.
+
+## Consequences
+
+Positive consequences:
+
+- Clustered write admission has an explicit safety boundary.
+- Brokers converge through deterministic committed coordination state.
+- Failure modes are observable and can be tested against concrete quorum and replay behavior.
+- Partitionless topic semantics remain intact.
+
+Negative consequences:
+
+- Clustered mode requires a quorum-capable coordination subsystem before accepting writes.
+- Conservative rejection can reduce availability during ambiguous failures.
+- Membership changes require careful rollout because they affect quorum and admission epochs.
+
+## Rollout or Migration Notes
+
+Implement standalone mode first with the same admission interface used by clustered mode. Add clustered coordination behind an explicit configuration path, initially with static voting membership.
+
+Before enabling dynamic membership, add a follow-up ADR for membership changes, reconfiguration safety, and operator workflows.
+
+Add behavior tests for loss of quorum, broker rejoin, unsafe-admission rejection, and partitionless writes accepted by different brokers in the same cluster.

--- a/docs/adr/0001-cluster-coordination.md
+++ b/docs/adr/0001-cluster-coordination.md
@@ -16,6 +16,8 @@ Kerald clustered mode will use a replicated coordination log for cluster metadat
 
 The initial clustered model will use a fixed voting set configured at cluster creation. A write is admissible only when the accepting broker can prove that the coordination quorum and required durability path are available for the current admission epoch. If quorum, storage, or replication health is uncertain, the broker rejects ingress with an explicit unsafe-admission error.
 
+The specific broker coordination algorithm is selected separately in ADR 0002. This ADR defines the required safety model and externally observable coordination behavior that the algorithm must satisfy.
+
 Replication expectations:
 
 - Coordination decisions require a quorum of the configured voting set.

--- a/docs/adr/0002-broker-coordination-subsystem.md
+++ b/docs/adr/0002-broker-coordination-subsystem.md
@@ -38,6 +38,30 @@ Protocol-level requirements for the coordination subsystem:
 4. **Recoverable view change**: failover must preserve safety and avoid split-brain commitment.
 5. **Efficient batching and pipelining**: implementation should favor high throughput and low overhead, aligned with Kerald's efficiency-first mission.
 
+## VSR Algorithm Summary
+
+Viewstamped Replication organizes a replica group around a monotonically increasing **view**. Each view has one primary and multiple backups. The primary orders client commands by appending them to a replicated operation log, while backups verify the current view, persist the ordered operation, and acknowledge it. Once the primary receives acknowledgements from a quorum, the operation is committed and can be applied to the deterministic state machine.
+
+For Kerald, the VSR log is a control-plane log rather than a client-visible offset model. It records cluster metadata, fencing epochs, admission state, and configuration decisions. The log may use internal operation numbers for replication, but those numbers must not become client progress cursors; client-visible progress remains based on nanosecond timestamps as required by ADR 0001.
+
+Normal operation:
+
+1. A broker routes or forwards an admissible control-plane command to the current primary for the active view.
+2. The primary assigns the next operation number, appends the command to its durable log, and sends a prepare message to backups.
+3. Backups reject messages from stale views, persist valid prepares in order, and acknowledge the primary.
+4. The primary commits the operation after quorum acknowledgement, advances the commit point, and broadcasts the committed point.
+5. Replicas apply committed operations in deterministic log order before exposing the resulting coordination state.
+
+View change and recovery:
+
+1. Replicas suspect the primary when progress stalls or the primary cannot prove quorum health.
+2. Replicas move to a higher view and exchange their durable log, commit point, and view metadata.
+3. The new primary is selected deterministically for the new view and reconstructs the safest log from quorum state.
+4. Any operation committed in an earlier view must be preserved in the new view.
+5. Brokers that are behind replay committed state before they can participate in write admission.
+
+TigerBeetle-style implementation choices should emphasize static or explicitly reconfigured replica sets, deterministic execution, bounded resource usage, batched prepares, pipelined replication, durable writes before acknowledgement, and aggressive fencing of stale primaries. These choices are intended to keep the coordination path efficient while preserving safety-first admission under ambiguous failures.
+
 ## Alternatives Considered
 
 1. **Classic Raft**

--- a/docs/adr/0002-broker-coordination-subsystem.md
+++ b/docs/adr/0002-broker-coordination-subsystem.md
@@ -1,0 +1,88 @@
+# ADR 0002: Broker Coordination Subsystem Based on TigerBeetle-Style VSR
+
+Status: Proposed
+
+## Context
+
+ADR 0001 defines Kerald's clustered coordination model: partitionless brokers, deterministic committed coordination state, and safety-first write admission whenever delivery guarantees cannot be proven.
+
+Kerald must now choose the concrete broker coordination subsystem that implements that model. In clustered mode, this subsystem is responsible for:
+
+- Maintaining a single, authoritative ordering of cluster metadata mutations.
+- Determining leadership and quorum health for admission control.
+- Ensuring that writes are rejected when eventual delivery guarantees cannot be upheld.
+- Enabling fast failover with bounded operational complexity.
+
+The system constraints in this repository require consistency and resilience principles inspired by TigerBeetle for coordination decisions. This ADR makes that requirement explicit and defines algorithmic boundaries for implementation.
+
+## Decision
+
+Kerald will implement broker coordination using a **TigerBeetle-style Viewstamped Replication (VSR) approach** as the default cluster coordination algorithm.
+
+Decision boundary:
+
+- **In scope**
+  - Replication and agreement for cluster control-plane state, including membership, leader view, fencing epochs, admission state, and configuration changes.
+  - Leader-based quorum protocol with deterministic state machine execution.
+  - Safety-first ingress gating tied to quorum and replication health.
+  - Timestamp-cursor compatibility for downstream delivery tracking without introducing offset semantics.
+- **Out of scope**
+  - Data-plane payload replication format and storage internals.
+  - External API protocol framing for QUIC, gRPC, MQTT, Kafka-compatible front doors, or other protocol extensions.
+
+Protocol-level requirements for the coordination subsystem:
+
+1. **Deterministic state machine**: all admitted control-plane commands must be applied in exactly the same order on all quorum replicas.
+2. **Single active leader per view**: fencing must prevent stale leaders from admitting writes.
+3. **Quorum-guarded admission**: brokers must reject ingress when quorum durability thresholds are not met.
+4. **Recoverable view change**: failover must preserve safety and avoid split-brain commitment.
+5. **Efficient batching and pipelining**: implementation should favor high throughput and low overhead, aligned with Kerald's efficiency-first mission.
+
+## Alternatives Considered
+
+1. **Classic Raft**
+   - Pros: mature ecosystem, widely understood, abundant operational knowledge.
+   - Cons: common implementations often optimize for generality over peak efficiency; less aligned with the TigerBeetle-inspired direction already required by project constraints.
+
+2. **Multi-Paxos / Paxos-family variants**
+   - Pros: strong theoretical basis and flexible deployment models.
+   - Cons: typically higher implementation and operational complexity; harder to keep ergonomics aligned with Kerald's simplicity goals.
+
+3. **EPaxos / leaderless bleeding-edge approaches**
+   - Pros: potential latency gains in some contention or topology patterns.
+   - Cons: significantly higher complexity, conflict handling overhead, and operational debugging burden for the control plane.
+
+4. **Centralized coordinator service without consensus**
+   - Pros: simpler implementation.
+   - Cons: single point of failure and inability to meet safety-first write admission in cluster failure scenarios.
+
+TigerBeetle-style VSR is selected because it balances modern performance-oriented design with deterministic safety properties and a manageable operational model.
+
+## Consequences
+
+Positive consequences:
+
+- Aligns directly with the repository's TigerBeetle-inspired coordination mandate.
+- Preserves safety-first admission under partial failures by coupling ingress to quorum health.
+- Supports deterministic, auditable control-plane progression and failover semantics.
+- Creates a clear boundary between control-plane consensus and partitionless data-plane ingestion.
+
+Negative consequences:
+
+- Smaller off-the-shelf ecosystem than generic Raft libraries; more implementation detail is likely to be in-repo.
+- Team onboarding requires familiarity with VSR and view-change semantics.
+- Additional rigor is needed for model-based and fault-injection testing of edge cases.
+
+## Rollout or Migration Notes
+
+Standalone mode remains unchanged and does not require consensus.
+
+Cluster mode rollout should proceed behind a coordination feature flag while validation suites are expanded. Required follow-up artifacts:
+
+1. Architecture document for broker coordination message flow and state transitions.
+2. Integration tests for leader failover, quorum loss, stale-leader fencing, and recovery.
+3. Performance tests for steady-state commit throughput and failover impact.
+4. Cucumber behavior scenarios for safety-first ingress rejection during quorum degradation.
+5. OTel metrics, traces, and log events for view changes, quorum health, commit latency, and admission rejections.
+
+No historical data migration is required for this ADR alone because it defines control-plane architecture, not persisted data format changes.

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -19,3 +19,8 @@ Each ADR must include:
 - Rollout or migration notes when applicable
 
 Number ADR files sequentially with a short kebab-case title, for example `0001-cluster-coordination.md`.
+
+## Current ADRs
+
+- `0001-cluster-coordination.md`: Cluster coordination model, safety boundary, quorum behavior, and observability expectations.
+- `0002-broker-coordination-subsystem.md`: Default clustered broker coordination algorithm using TigerBeetle-style VSR.


### PR DESCRIPTION
## Summary

Implements #3 by adding ADR coverage for the TigerBeetle-inspired clustered coordination model and broker coordination subsystem.

- Defines the coordination consistency model around a replicated committed log in ADR 0001.
- Adds ADR 0002 for the concrete broker coordination subsystem proposal using TigerBeetle-style VSR.
- Describes the VSR algorithm flow: views, primary/backup roles, prepare/commit handling, quorum acknowledgement, view change, and recovery.
- Captures replication expectations, quorum behavior, failure handling, and safety-first write admission.
- Identifies required observability signals for coordination health and follow-up validation suites.
- Renumbers ADRs coherently so the general cluster coordination model precedes the concrete broker subsystem decision.

## Validation

- `git diff --check`
- `grep -RIn "0001-broker\|0002-broker\|ADR 0002\|ADR 0001" docs/adr --exclude-dir=.git`
- `sed -n '1,260p' docs/adr/0002-broker-coordination-subsystem.md`

Closes #3