### PR TITLE
docs: define runtime binding targets

### DIFF
--- a/docs/architecture/language-bindings.md
+++ b/docs/architecture/language-bindings.md
@@ -1,0 +1,23 @@
+# Language Binding Architecture
+
+Kerald language bindings should wrap the same core broker/client semantics instead of creating language-specific behavior.
+
+Shared binding requirements:
+
+- Preserve partitionless topic APIs.
+- Use nanosecond timestamp cursors for progress.
+- Keep notification tracking separate from payload delivery tracking.
+- Surface safety-first admission rejection as an explicit error.
+- Represent payloads through Arrow-compatible data boundaries.
+
+## Python Binding Shape
+
+Python bindings use PyO3 to expose a native Python package for Python 3.10+.
+
+The binding should keep native resource ownership explicit and should avoid broker-side blocking semantics for payload polling. Python APIs may provide ergonomic wrappers, but those wrappers must not change Kerald's delivery, notification, or cursor guarantees.
+
+## Java Binding Shape
+
+Java bindings use Java 25+ FFM API access to native Kerald libraries.
+
+The Java package should manage native memory through FFM resource scopes and must not introduce JNI. Any Java compatibility layer should remain a front door over the same Kerald client semantics rather than a separate protocol model.

--- a/docs/requirements/runtime-and-bindings.md
+++ b/docs/requirements/runtime-and-bindings.md
@@ -1,0 +1,33 @@
+# Runtime and Binding Targets
+
+Kerald targets these language and runtime boundaries:
+
+- Rust 1.92 for broker and core library implementation.
+- Python 3.10+ bindings through PyO3.
+- Java 25+ bindings through the FFM API.
+
+JNI is not allowed for Java bindings.
+
+## Rust
+
+Rust is the implementation language for Kerald's broker and core libraries. Repository build configuration should pin or document Rust 1.92 before Rust source is introduced.
+
+New Rust crates may be added only when they are actively maintained at the time they are added and licensed under MIT or Apache-2.0.
+
+## Python
+
+Python bindings must use PyO3 and support Python 3.10 or newer.
+
+The Python binding boundary should expose client-facing APIs over stable Kerald concepts: topics, timestamp cursors, payload polling, notifications, and admission errors. It must not expose partition APIs or offset-based progress.
+
+## Java
+
+Java bindings must target Java 25 or newer and use the Foreign Function and Memory API.
+
+Java bindings must not use JNI. Any build or source layout that introduces JNI headers, JNI loaders, or JNI bridge code is incompatible with Kerald's binding policy.
+
+## CI Expectations
+
+The repository CI already includes conditional Rust, Python, and Java build jobs. Those jobs activate when the matching project manifests are added.
+
+When implementation files are introduced, the same pull request should add the relevant manifest, build command, and test coverage so CI enforces the target runtime.


### PR DESCRIPTION
## Summary

Implements #13 by documenting Kerald's runtime and language binding targets.

- Documents Rust 1.92 as the broker/core implementation target.
- Defines Python 3.10+ bindings through PyO3.
- Defines Java 25+ bindings through the FFM API and explicitly rejects JNI.
- Captures binding architecture invariants around partitionless APIs, timestamp cursors, notification/payload separation, admission errors, and Arrow-compatible payload boundaries.
- Notes that new Rust crates must be actively maintained and MIT or Apache-2.0 licensed.

## Validation

- `test -f AGENTS.md && jq empty .devcontainer/devcontainer.json && jq empty .vscode/extensions.json && git diff --check`

Closes #13