### PR TITLE
[codex] Add async broker runtime boundary

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -31,10 +31,10 @@ clap = { version = "4.6.1", features = ["derive"] }
 config = { version = "0.15.22", default-features = false, features = ["toml", "json", "yaml"] }
 serde = { version = "1.0.228", features = ["derive"] }
 thiserror = "2.0.18"
+tokio = { version = "1.52.1", features = ["macros", "rt-multi-thread"] }
 tracing = "0.1.44"
 tracing-subscriber = { version = "0.3.23", features = ["fmt", "env-filter"] }
 uuid = { version = "1.23.1", features = ["serde", "v4"] }
 
 [dev-dependencies]
 cucumber = "0.23.0"
-tokio = { version = "1.52.1", features = ["macros", "rt-multi-thread"] }

--- a/core/src/bin/kerald.rs
+++ b/core/src/bin/kerald.rs
@@ -11,7 +11,8 @@ struct Cli {
     config: Option<PathBuf>,
 }
 
-fn main() -> Result<(), Box<dyn std::error::Error>> {
+#[tokio::main]
+async fn main() -> Result<(), Box<dyn std::error::Error>> {
     init_tracing();
 
     let cli = Cli::parse();
@@ -20,7 +21,7 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
         None => BrokerConfig::single_node(NonZeroU16::new(9000).expect("default inter-broker port is non-zero")),
     };
 
-    let broker = Broker::new(config).start();
+    let broker = Broker::new(config).start().await?;
     let cluster = broker.config().cluster();
 
     info!(

--- a/core/src/broker.rs
+++ b/core/src/broker.rs
@@ -185,7 +185,7 @@ impl Broker {
         }
     }
 
-    pub fn start(self) -> RunningBroker {
+    pub async fn start(self) -> Result<RunningBroker, BrokerError> {
         let expected_brokers = self.config.cluster().expected_brokers();
         let quorum_size = self.config.cluster().quorum_size();
 
@@ -223,12 +223,12 @@ impl Broker {
             )
         };
 
-        RunningBroker {
+        Ok(RunningBroker {
             local_node_id: self.local_node_id,
             config: self.config,
             discovery_state,
             admission_state,
-        }
+        })
     }
 }
 

--- a/docs/adr/0003-async-broker-runtime.md
+++ b/docs/adr/0003-async-broker-runtime.md
@@ -1,0 +1,54 @@
+# ADR 0003: Async Broker Runtime Boundary
+
+Status: Proposed
+
+## Context
+
+Kerald's broker will serve many concurrent client, inter-broker, persistence, and telemetry operations while preserving safety-first admission and partitionless topic semantics. The runtime boundary must support efficient QUIC transport, dynamic voter discovery, VSR-style coordination, OpenDAL-backed storage, Lance read/write paths, subscriber polling, and OTel telemetry without dedicating one operating-system thread to each concurrent activity.
+
+The first broker startup slice only evaluated static configuration and local admission state, so synchronous startup was sufficient for that limited behavior. As soon as broker lifecycle touches networking, storage, coordination tasks, timers, or graceful shutdown, synchronous APIs would force inefficient blocking or require a later public API break.
+
+This decision does not change Kerald's client-facing invariants: topics remain partitionless, progress uses nanosecond timestamp cursors, notification tracking remains separate from payload delivery tracking, and brokers reject ingress when eventual delivery guarantees cannot be proven.
+
+## Decision
+
+Kerald broker lifecycle APIs are async-first. `Broker::start` is an async, fallible boundary owned by the broker runtime. The CLI binary owns a Tokio multi-thread runtime through `#[tokio::main]`.
+
+Pure value construction and deterministic configuration parsing remain synchronous unless they perform I/O that benefits from async execution. Examples include `BrokerConfig::single_node`, quorum calculation, and validation of in-memory values.
+
+Runtime implementation guidance:
+
+- Network transport, inter-broker discovery, coordination, storage, subscriber polling, timers, telemetry export, and graceful shutdown paths should use async APIs.
+- Broker startup should fail explicitly when required runtime resources cannot be initialized.
+- Background tasks must have explicit ownership and shutdown behavior rather than being detached without lifecycle control.
+- CPU-heavy Arrow work should be batched and isolated from async I/O progress when needed, for example through dedicated compute or blocking pools.
+- Backpressure should be explicit through bounded queues, admission state, and resource limits.
+
+## Alternatives Considered
+
+Keeping broker lifecycle synchronous until the first concrete async transport was rejected because it would let synchronous public APIs harden before the messaging hot path exists.
+
+Adding sync and async startup variants was rejected because it creates two lifecycle surfaces for a broker that is fundamentally I/O-oriented.
+
+Using one thread per connection or operation was rejected because it conflicts with Kerald's efficiency-first mission and would not scale cleanly for QUIC streams, subscriber polling, storage calls, and coordination traffic.
+
+## Consequences
+
+Positive consequences:
+
+- The public broker lifecycle matches the expected I/O-heavy implementation model.
+- QUIC, OpenDAL, coordination, polling, timers, and telemetry can compose without blocking runtime worker threads.
+- Runtime startup failures can be propagated before a broker is considered running.
+- Future task ownership and graceful shutdown work has a clear API boundary.
+
+Negative consequences:
+
+- Tests and embedding code must run inside an async runtime.
+- The binary depends on Tokio before the first concrete transport task lands.
+- Purely synchronous bootstrap code now uses an async call even when no await point is currently needed internally.
+
+## Rollout or Migration Notes
+
+The initial rollout converts `Broker::start` to `async fn start(self) -> Result<RunningBroker, BrokerError>` and updates the CLI, integration tests, and behavior tests to await startup.
+
+Follow-up work should add explicit task supervision and graceful shutdown once transport, discovery, coordination, or storage tasks are introduced. Behavior and integration suites should cover startup failure, shutdown, admission rejection under runtime failures, and preservation of partitionless timestamp-cursor semantics.

--- a/docs/adr/0003-async-broker-runtime.md
+++ b/docs/adr/0003-async-broker-runtime.md
@@ -12,7 +12,9 @@ This decision does not change Kerald's client-facing invariants: topics remain p
 
 ## Decision
 
-Kerald broker lifecycle APIs are async-first. `Broker::start` is an async, fallible boundary owned by the broker runtime. The CLI binary owns a Tokio multi-thread runtime through `#[tokio::main]`.
+Kerald broker lifecycle APIs are async-first. `Broker::start` is an async, fallible boundary owned by the broker server runtime. The long-running broker process owns a Tokio runtime through its server entrypoint.
+
+The operator CLI is a separate control surface. CLI operations should be finite commands that communicate with a running broker process to start, stop, inspect, or modify behavior. They must not become the long-running broker runtime merely because they perform control-plane work.
 
 Pure value construction and deterministic configuration parsing remain synchronous unless they perform I/O that benefits from async execution. Examples include `BrokerConfig::single_node`, quorum calculation, and validation of in-memory values.
 
@@ -21,8 +23,9 @@ Runtime implementation guidance:
 - Network transport, inter-broker discovery, coordination, storage, subscriber polling, timers, telemetry export, and graceful shutdown paths should use async APIs.
 - Broker startup should fail explicitly when required runtime resources cannot be initialized.
 - Background tasks must have explicit ownership and shutdown behavior rather than being detached without lifecycle control.
-- CPU-heavy Arrow work should be batched and isolated from async I/O progress when needed, for example through dedicated compute or blocking pools.
+- Brokers must treat Arrow as the in-memory exchange format, not as permission to perform compute-heavy query, compaction, optimization, or analytics work inside the broker process. Those workloads belong in dedicated modules or external systems.
 - Backpressure should be explicit through bounded queues, admission state, and resource limits.
+- High-priority control paths, including shutdown hooks, should have protected execution capacity through distinct task supervisors, queues, or Tokio execution pools so they remain responsive under data-plane load.
 
 ## Alternatives Considered
 
@@ -30,7 +33,7 @@ Keeping broker lifecycle synchronous until the first concrete async transport wa
 
 Adding sync and async startup variants was rejected because it creates two lifecycle surfaces for a broker that is fundamentally I/O-oriented.
 
-Using one thread per connection or operation was rejected because it conflicts with Kerald's efficiency-first mission and would not scale cleanly for QUIC streams, subscriber polling, storage calls, and coordination traffic.
+Using one thread per connection or operation was rejected because it conflicts with Kerald's efficiency-first mission and would not scale cleanly for QUIC streams, subscriber polling, storage calls, and coordination traffic. This rejection does not preclude distinct async execution pools for control-plane priority or shutdown responsiveness.
 
 ## Consequences
 
@@ -40,15 +43,16 @@ Positive consequences:
 - QUIC, OpenDAL, coordination, polling, timers, and telemetry can compose without blocking runtime worker threads.
 - Runtime startup failures can be propagated before a broker is considered running.
 - Future task ownership and graceful shutdown work has a clear API boundary.
+- Control-plane operations can be designed as finite CLI commands against a running process instead of being conflated with the long-running broker runtime.
 
 Negative consequences:
 
 - Tests and embedding code must run inside an async runtime.
-- The binary depends on Tokio before the first concrete transport task lands.
+- The broker server binary depends on Tokio before the first concrete transport task lands.
 - Purely synchronous bootstrap code now uses an async call even when no await point is currently needed internally.
 
 ## Rollout or Migration Notes
 
-The initial rollout converts `Broker::start` to `async fn start(self) -> Result<RunningBroker, BrokerError>` and updates the CLI, integration tests, and behavior tests to await startup.
+The initial rollout converts `Broker::start` to `async fn start(self) -> Result<RunningBroker, BrokerError>` and updates the broker server entrypoint, integration tests, and behavior tests to await startup.
 
-Follow-up work should add explicit task supervision and graceful shutdown once transport, discovery, coordination, or storage tasks are introduced. Behavior and integration suites should cover startup failure, shutdown, admission rejection under runtime failures, and preservation of partitionless timestamp-cursor semantics.
+Follow-up work should add explicit task supervision, protected control-plane execution, and graceful shutdown once transport, discovery, coordination, or storage tasks are introduced. Behavior and integration suites should cover startup failure, shutdown, admission rejection under runtime failures, and preservation of partitionless timestamp-cursor semantics.

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -24,3 +24,4 @@ Number ADR files sequentially with a short kebab-case title, for example `0001-c
 
 - `0001-cluster-coordination.md`: Cluster coordination model, safety boundary, quorum behavior, and observability expectations.
 - `0002-broker-coordination-subsystem.md`: Default clustered broker coordination algorithm using TigerBeetle-style VSR.
+- `0003-async-broker-runtime.md`: Async-first broker lifecycle and runtime boundary.

--- a/docs/architecture/README.md
+++ b/docs/architecture/README.md
@@ -10,4 +10,8 @@ Architecture documents should explain component boundaries, protocols, data flow
 - Write admission is safety-first.
 - Persistence is Lance read/write only behind OpenDAL-backed storage boundaries.
 
+Current architecture notes:
+
+- `broker-runtime.md`: Async-first broker lifecycle and runtime boundary.
+
 When an architecture document records a long-lived decision rather than explanatory context, add or update an ADR in `docs/adr/`.

--- a/docs/architecture/broker-runtime.md
+++ b/docs/architecture/broker-runtime.md
@@ -1,0 +1,17 @@
+# Broker Runtime
+
+Kerald's broker runtime is async-first for lifecycle and I/O-facing behavior.
+
+Synchronous APIs are appropriate for pure value construction, deterministic validation, and in-memory configuration helpers. Runtime APIs that may touch transport, storage, coordination, timers, telemetry export, subscriber polling, or graceful shutdown should be async and fallible.
+
+The broker binary owns the Tokio runtime. Library callers embed Kerald by awaiting broker lifecycle APIs inside their own runtime.
+
+Runtime boundaries must preserve the mandatory architecture constraints:
+
+- Topics are partitionless, and runtime task layout must not introduce partition ownership assumptions.
+- Client progress uses nanosecond timestamp cursors, not offsets.
+- Notification tracking remains independent from payload delivery tracking.
+- Write admission is safety-first and rejects ingress when delivery guarantees cannot be proven.
+- Persistence remains Lance read/write only behind OpenDAL-backed storage.
+
+As transport and persistence arrive, runtime components should use bounded queues, explicit backpressure, clear task ownership, OTel logs/metrics/traces, and graceful shutdown hooks. CPU-heavy Arrow work should not block async I/O progress; use batching or dedicated compute execution when needed.

--- a/docs/architecture/broker-runtime.md
+++ b/docs/architecture/broker-runtime.md
@@ -4,7 +4,9 @@ Kerald's broker runtime is async-first for lifecycle and I/O-facing behavior.
 
 Synchronous APIs are appropriate for pure value construction, deterministic validation, and in-memory configuration helpers. Runtime APIs that may touch transport, storage, coordination, timers, telemetry export, subscriber polling, or graceful shutdown should be async and fallible.
 
-The broker binary owns the Tokio runtime. Library callers embed Kerald by awaiting broker lifecycle APIs inside their own runtime.
+The broker server process owns the Tokio runtime. Library callers embed Kerald by awaiting broker lifecycle APIs inside their own runtime.
+
+Operator CLI commands are distinct from the broker server process. They should perform finite control-plane operations by communicating with a running broker process to start, stop, inspect, or modify behavior.
 
 Runtime boundaries must preserve the mandatory architecture constraints:
 
@@ -14,4 +16,4 @@ Runtime boundaries must preserve the mandatory architecture constraints:
 - Write admission is safety-first and rejects ingress when delivery guarantees cannot be proven.
 - Persistence remains Lance read/write only behind OpenDAL-backed storage.
 
-As transport and persistence arrive, runtime components should use bounded queues, explicit backpressure, clear task ownership, OTel logs/metrics/traces, and graceful shutdown hooks. CPU-heavy Arrow work should not block async I/O progress; use batching or dedicated compute execution when needed.
+As transport and persistence arrive, runtime components should use bounded queues, explicit backpressure, clear task ownership, OTel logs/metrics/traces, protected control-plane execution, and graceful shutdown hooks. Arrow is the broker's in-memory exchange format; compute-heavy query, compaction, optimization, and analytics work belongs outside the broker process.

--- a/docs/requirements/broker-modes.md
+++ b/docs/requirements/broker-modes.md
@@ -34,6 +34,10 @@ all cluster sizes: topics are partitionless, progress uses nanosecond timestamp
 cursors, and notification tracking remains independent from payload delivery
 tracking.
 
+Broker lifecycle APIs are async-first. Startup is fallible and awaited by the
+runtime owner so future QUIC, coordination, storage, polling, telemetry, and
+shutdown work can be initialized without blocking worker threads.
+
 ## Configuration Files
 
 Broker configuration is loaded through a parser that supports multiple

--- a/tests/cucumber/broker_modes.rs
+++ b/tests/cucumber/broker_modes.rs
@@ -37,7 +37,7 @@ async fn inter_broker_port(world: &mut BrokerWorld, port: u16) {
 #[when("the broker starts")]
 async fn broker_starts(world: &mut BrokerWorld) {
     let config = world.config.take().expect("scenario should configure broker before startup");
-    world.broker = Some(Broker::new(config).start());
+    world.broker = Some(Broker::new(config).start().await.expect("broker should start"));
 }
 
 #[then(expr = "the cluster quorum is {int}")]

--- a/tests/integration/broker_startup.rs
+++ b/tests/integration/broker_startup.rs
@@ -5,9 +5,12 @@ fn port(value: u16) -> NonZeroU16 {
     NonZeroU16::new(value).expect("test port should be non-zero")
 }
 
-#[test]
-fn single_node_cluster_starts_with_generated_identity_and_local_admission_enabled() {
-    let broker = Broker::new(BrokerConfig::single_node(port(9000))).start();
+#[tokio::test]
+async fn single_node_cluster_starts_with_generated_identity_and_local_admission_enabled() {
+    let broker = Broker::new(BrokerConfig::single_node(port(9000)))
+        .start()
+        .await
+        .expect("single-node broker should start");
 
     assert_ne!(broker.local_node_id().as_uuid(), uuid::Uuid::nil());
     assert_eq!(broker.config().cluster().expected_brokers().get(), 1);
@@ -22,13 +25,15 @@ fn single_node_cluster_starts_with_generated_identity_and_local_admission_enable
     assert!(broker.admission_state().admits_writes());
 }
 
-#[test]
-fn multi_node_cluster_discovers_only_local_voter_at_startup_and_rejects_writes_until_quorum() {
+#[tokio::test]
+async fn multi_node_cluster_discovers_only_local_voter_at_startup_and_rejects_writes_until_quorum() {
     let broker = Broker::new(BrokerConfig::new(
         ClusterConfig::new(NonZeroUsize::new(3).expect("cluster size should be non-zero")),
         InterBrokerConfig::new(port(9000)),
     ))
-    .start();
+    .start()
+    .await
+    .expect("multi-node broker should start in rejecting admission state");
 
     assert_ne!(broker.local_node_id().as_uuid(), uuid::Uuid::nil());
     assert_eq!(broker.config().cluster().expected_brokers().get(), 3);


### PR DESCRIPTION
## Summary

- Convert `Broker::start` into an async, fallible lifecycle boundary.
- Run the broker CLI on a Tokio runtime and await startup.
- Update integration and Cucumber behavior coverage for async startup.
- Document the async runtime boundary in requirements, architecture notes, and ADR 0003.

## Why Draft

This is ready for early review as an atomic foundation slice, but I am opening it as a draft because the runtime boundary is intended to support upcoming QUIC, coordination, storage, telemetry, and graceful-shutdown work. I want review on the API shape before chaining the next implementation PRs on top of it.

## Validation

- `cargo fmt --check`
- `cargo test --workspace`
- `cargo clippy --workspace --all-targets -- -D warnings`

## Kerald Quality Gate

- [x] Partitionless semantics preserved.
- [x] Timestamp cursor semantics preserved.
- [x] Notification vs delivery separation preserved.
- [x] Safety-first write admission preserved.
- [x] Tests added/updated in correct suite(s): integration and behavior suites updated; unit/performance not needed for this lifecycle API slice.
- [x] Telemetry impact reviewed: existing tracing logs remain; ADR calls out OTel requirements for future runtime tasks.
- [x] Docs/ADR updated for runtime boundary decision.
- [x] Runtime/container impact considered: adds Tokio runtime dependency; no container changes in this slice.