### PR TITLE
[codex] Add runtime container image baseline

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,8 @@
+**
+
+!Cargo.toml
+!Cargo.lock
+!rustfmt.toml
+!core/
+!core/src/
+!core/src/**

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,31 @@
+# syntax=docker/dockerfile:1.7
+
+ARG RUST_VERSION=1.95
+ARG ALPINE_VERSION=3.22
+
+FROM rust:${RUST_VERSION}-alpine AS builder
+
+WORKDIR /workspace
+
+RUN apk add --no-cache musl-dev
+
+COPY Cargo.toml Cargo.lock rustfmt.toml ./
+COPY core/src ./core/src
+
+RUN cargo build --locked --release --bin kerald
+
+FROM alpine:${ALPINE_VERSION} AS runtime
+
+RUN addgroup -S kerald \
+    && adduser -S -D -G kerald -h /var/lib/kerald -s /sbin/nologin kerald \
+    && apk add --no-cache ca-certificates
+
+COPY --from=builder /workspace/target/release/kerald /usr/local/bin/kerald
+
+USER kerald
+WORKDIR /var/lib/kerald
+
+# Mirrors the broker's current default QUIC inter-broker port.
+EXPOSE 9000/udp
+
+ENTRYPOINT ["/usr/local/bin/kerald"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,21 +1,28 @@
-# syntax=docker/dockerfile:1.7
+# syntax=docker/dockerfile:1.23
 
 ARG RUST_VERSION=1.95
-ARG ALPINE_VERSION=3.22
+ARG ALPINE_VERSION=3.23
 
+# Build with the Rust musl Alpine toolchain required for lightweight Kerald
+# runtime nodes.
 FROM rust:${RUST_VERSION}-alpine AS builder
 
 WORKDIR /workspace
 
 RUN apk add --no-cache musl-dev
 
+# Keep the build context focused on the broker/runtime Rust source. Future
+# client sources and language bindings should not be copied into this image.
 COPY Cargo.toml Cargo.lock rustfmt.toml ./
 COPY core/src ./core/src
 
 RUN cargo build --locked --release --bin kerald
 
+# Runtime stage contains only the broker binary and minimal TLS roots.
 FROM alpine:${ALPINE_VERSION} AS runtime
 
+# Create a system group and disabled-login system user so the broker never runs
+# as root. The home directory is the broker workdir for future local state.
 RUN addgroup -S kerald \
     && adduser -S -D -G kerald -h /var/lib/kerald -s /sbin/nologin kerald \
     && apk add --no-cache ca-certificates

--- a/docs/operations/README.md
+++ b/docs/operations/README.md
@@ -8,4 +8,5 @@ Operational documents should cover deployment expectations, failure handling, ro
 - musl Alpine multi-stage container builds for lightweight runtime nodes.
 - Explicit failure-mode handling for write admission, storage, delivery, and cluster coordination.
 
-See `github-merge-gates.md` for repository merge protection and CI requirements.
+See `container-images.md` for production image expectations and
+`github-merge-gates.md` for repository merge protection and CI requirements.

--- a/docs/operations/container-images.md
+++ b/docs/operations/container-images.md
@@ -1,0 +1,50 @@
+# Container Images
+
+Kerald production containers must stay lightweight and operationally simple.
+Images are built with a musl Alpine multi-stage flow:
+
+- The builder stage uses the Rust 1.95 Alpine toolchain and compiles the
+  `kerald` broker binary with `cargo build --locked --release --bin kerald`.
+- The runtime stage uses Alpine and copies only the compiled broker binary plus
+  minimal certificate support.
+- The runtime process runs as an unprivileged `kerald` user with no shell.
+- The default exposed inter-broker port is `9000/udp`, matching the current QUIC
+  protocol baseline and the broker's current default development port.
+
+Build the image from the repository root:
+
+```sh
+docker build -t kerald:local .
+```
+
+Run a development single-node broker with the built image:
+
+```sh
+docker run --rm -p 9000:9000/udp kerald:local
+```
+
+For hardened local runs, drop Linux capabilities and prevent privilege
+escalation:
+
+```sh
+docker run --rm \
+  --cap-drop=ALL \
+  --security-opt no-new-privileges \
+  -p 9000:9000/udp \
+  kerald:local
+```
+
+Run with a mounted broker configuration:
+
+```sh
+docker run --rm \
+  -p 9000:9000/udp \
+  -v "$PWD/kerald.toml:/etc/kerald/kerald.toml:ro" \
+  kerald:local --config /etc/kerald/kerald.toml
+```
+
+Container changes must continue to preserve partitionless topic semantics,
+safety-first write admission, timestamp cursor semantics, and the broker
+boundary that keeps Lance persistence and OpenDAL storage responsibilities out
+of the runtime image unless those dependencies are required by the broker
+binary.

--- a/docs/operations/container-images.md
+++ b/docs/operations/container-images.md
@@ -8,6 +8,8 @@ Images are built with a musl Alpine multi-stage flow:
 - The runtime stage uses Alpine and copies only the compiled broker binary plus
   minimal certificate support.
 - The runtime process runs as an unprivileged `kerald` user with no shell.
+- Production runs should drop all Linux capabilities and set Docker's
+  `no-new-privileges` security option.
 - The default exposed inter-broker port is `9000/udp`, matching the current QUIC
   protocol baseline and the broker's current default development port.
 
@@ -17,14 +19,7 @@ Build the image from the repository root:
 docker build -t kerald:local .
 ```
 
-Run a development single-node broker with the built image:
-
-```sh
-docker run --rm -p 9000:9000/udp kerald:local
-```
-
-For hardened local runs, drop Linux capabilities and prevent privilege
-escalation:
+Run a production-ready single-node broker with the built image:
 
 ```sh
 docker run --rm \
@@ -34,10 +29,18 @@ docker run --rm \
   kerald:local
 ```
 
+For local development only, the security flags may be omitted:
+
+```sh
+docker run --rm -p 9000:9000/udp kerald:local
+```
+
 Run with a mounted broker configuration:
 
 ```sh
 docker run --rm \
+  --cap-drop=ALL \
+  --security-opt no-new-privileges \
   -p 9000:9000/udp \
   -v "$PWD/kerald.toml:/etc/kerald/kerald.toml:ro" \
   kerald:local --config /etc/kerald/kerald.toml


### PR DESCRIPTION
## Summary

Adds a lightweight musl Alpine multi-stage Docker build for the Kerald broker runtime.

## What changed

- Added a root `Dockerfile` that builds `kerald` with Rust 1.95 on Alpine and copies only the release binary into an Alpine runtime image.
- Added a default-deny `.dockerignore` so the Docker context includes only Cargo manifests and `core/src`, avoiding future client Rust sources and Python/Java bindings.
- Added container operations notes covering build/run commands, the current `9000/udp` QUIC default, and hardened runtime flags.
- Linked the container notes from the operations index.

## Review comment handling

- `9000/udp` is documented as mirroring the broker's current default QUIC inter-broker development port.
- Runtime image uses the unprivileged `kerald` user with no shell; docs include `--cap-drop=ALL` and `--security-opt no-new-privileges` for hardened runs.

## Quality gate

- Partitionless semantics preserved: no broker behavior changes.
- Timestamp cursor semantics preserved: no cursor code changes.
- Notification vs delivery separation preserved: no subscriber behavior changes.
- Safety-first write admission preserved: no admission behavior changes.
- Tests: `cargo test --locked`.
- Container validation: `docker build --progress=plain -t kerald:container-pr .`.
- Runtime user validation: `docker run --rm --entrypoint id kerald:container-pr` returned `uid=100(kerald)`.
- Telemetry impact reviewed: no OTel behavior changes.
- Runtime/container impact considered: musl Alpine multi-stage image with narrowed build context.